### PR TITLE
[BUGFIX] Drop shared library inside lxc folder

### DIFF
--- a/ext/lxc/extconf.rb
+++ b/ext/lxc/extconf.rb
@@ -4,4 +4,4 @@ abort 'missing liblxc' unless find_library('lxc', 'lxc_container_new')
 abort 'missing lxc/lxccontainer.h' unless have_header('lxc/lxccontainer.h')
 
 $CFLAGS += " -Wall #{ENV['CFLAGS']}"
-create_makefile('lxc')
+create_makefile('lxc/lxc')


### PR DESCRIPTION
Fix this:  https://github.com/lxc/ruby-lxc/issues/4
