### PR TITLE
Tests should not fail if there are pre-existing containers

### DIFF
--- a/test/test_lxc_class_methods.rb
+++ b/test/test_lxc_class_methods.rb
@@ -15,7 +15,7 @@ class TestLXCClassMethods < Test::Unit::TestCase
   end
 
   def test_list_containers
-    assert_equal([@name], LXC.list_containers)
+    assert(LXC.list_containers.include?('test'))
   end
 
   def test_arch_to_personality

--- a/test/test_lxc_running.rb
+++ b/test/test_lxc_running.rb
@@ -103,7 +103,7 @@ class TestLXCRunning < Test::Unit::TestCase
 
   def test_container_listed
     containers = LXC.list_containers
-    assert_equal(1, containers.length)
-    assert_equal(@name, containers.first)
+    assert(containers.length > 0)
+    assert(containers.include?(@name))
   end
 end


### PR DESCRIPTION
assert against the presence of test container against LXC.list_containers return, avoid array comparison.
