### PR TITLE
Rescue LXCError is shutdown does not work, so that stop method is reachable

### DIFF
--- a/test/test_lxc_running.rb
+++ b/test/test_lxc_running.rb
@@ -16,7 +16,7 @@ class TestLXCRunning < Test::Unit::TestCase
   end
 
   def teardown
-    @container.shutdown(3)
+    @container.shutdown(3) rescue nil
     if @container.running?
       @container.stop
       @container.wait(:stopped, 3)


### PR DESCRIPTION
Currently the teardown method attempts to stop the container if shutdown does not work. But a failed shutdown call throws LXCError, making the stop call unreachable
