### PR TITLE
Allow start(:single_arg => value)

### DIFF
--- a/ext/lxc/lxc.c
+++ b/ext/lxc/lxc.c
@@ -1903,16 +1903,20 @@ container_start(int argc, VALUE *argv, VALUE self)
     if (!NIL_P(rb_opts)) {
         Check_Type(rb_opts, T_HASH);
         rb_use_init = rb_hash_aref(rb_opts, SYMBOL("use_init"));
-        args.use_init = (rb_use_init != Qnil) && (rb_use_init != Qfalse);
+        if (!NIL_P(rb_use_init))
+            args.use_init = (rb_use_init != Qfalse);
 
         rb_daemonize = rb_hash_aref(rb_opts, SYMBOL("daemonize"));
-        args.daemonize = (rb_daemonize != Qnil) && (rb_daemonize != Qfalse);
+        if (!NIL_P(rb_daemonize))
+            args.daemonize = (rb_daemonize != Qfalse);
 
         rb_close_fds = rb_hash_aref(rb_opts, SYMBOL("close_fds"));
-        args.close_fds = (rb_close_fds != Qnil) && (rb_close_fds != Qfalse);
+        if (!NIL_P(rb_close_fds))
+            args.close_fds = (rb_close_fds != Qfalse);
 
         rb_args = rb_hash_aref(rb_opts, SYMBOL("args"));
-        args.args = NIL_P(rb_args) ? NULL : ruby_to_c_string_array(rb_args);
+        if (!NIL_P(rb_args))
+            args.args = ruby_to_c_string_array(rb_args);
     }
 
     Data_Get_Struct(self, struct container_data, args.data);

--- a/test/test_lxc_created.rb
+++ b/test/test_lxc_created.rb
@@ -51,4 +51,16 @@ class TestLXCCreated < Test::Unit::TestCase
     rerenamed = renamed.rename(@name)
     assert_equal(@name, rerenamed.name)
   end
+
+  def test_start
+    @container.stop if @container.running?
+    @container.start
+    assert(@container.running?)
+  end
+
+  def test_start_with_args
+    @container.stop if @container.running?
+    @container.start(:close_fds => true)
+    assert(@container.running?)
+  end
 end


### PR DESCRIPTION
In Ruby, the general expectation is that if container.start() works with defaults for parameters a, b, c, and d, then container.start(:a => 'x') will still set defaults for parameters b, c, and d.  This patch Makes It So :)
