### PR TITLE
Fixing clear_config & config_item value

### DIFF
--- a/ext/lxc/lxc.c
+++ b/ext/lxc/lxc.c
@@ -1238,6 +1238,9 @@ container_config_item(VALUE self, VALUE rb_key)
     if (len1 < 0)
         rb_raise(Error, "invalid configuration key: %s", key);
 
+    if (len1 == 0)
+        return Qnil;
+
     value = malloc(sizeof(char) * len1 + 1);
     if (value == NULL)
         rb_raise(rb_eNoMemError, "unable to allocate configuration value");

--- a/test/test_lxc_created.rb
+++ b/test/test_lxc_created.rb
@@ -41,6 +41,26 @@ class TestLXCCreated < Test::Unit::TestCase
     assert_match(/^00:16:3e:/, @container.config_item('lxc.network.0.hwaddr'))
   end
 
+  def test_container_fstab
+    config_path = @container.config_path + '/' + @name + '/config'
+    fstab_path  = @container.config_path + '/' + @name + '/fstab'
+
+    @container.set_config_item('lxc.mount', fstab_path)
+    @container.save_config(config_path)
+
+    assert_instance_of(String, @container.config_item('lxc.mount'))
+    assert_not_nil(@container.config_item('lxc.mount'))
+
+    f = File.readlines(config_path)
+    f.reject! { |l| /^lxc\.mount = (.*)$/ =~ l }
+    File.write(config_path, f.join)
+
+    @container.clear_config
+    @container.load_config(config_path)
+
+    assert(@container.config_item('lxc.mount').nil?)
+  end
+
   def test_clear_config
       assert_not_nil(@container.config_item('lxc.utsname'))
       assert(@container.clear_config)


### PR DESCRIPTION
Hi, 

I've made 2 fix and added 2 tests for these. First commit for clear_config, the method was not callable.
The second for the config_item method, for returning nil value in case of empty value (length = 0). Currently a random string is retrieved (tested on "lxc.mount" item).
I do only 1 PR for these 2 patches since the test for the config_item need the fix on clear_config (unless there is better way to reload the config ?).
