### PR TITLE
Correcting compilation for the last lxc development version.

### DIFF
--- a/ext/lxc/lxc.c
+++ b/ext/lxc/lxc.c
@@ -51,20 +51,6 @@ struct container_data {
     struct lxc_container *container;
 };
 
-struct bdev_specs {
-    char *fstype;
-    uint64_t fssize;  // fs size in bytes
-    struct {
-        char *zfsroot;
-    } zfs;
-    struct {
-        char *vg;
-        char *lv;
-        char *thinpool; // lvm thin pool to use, if any
-    } lvm;
-    char *dir;
-};
-
 static char **
 ruby_to_c_string_array(VALUE rb_arr)
 {


### PR DESCRIPTION
Hi,  

[This commit](https://github.com/lxc/ruby-lxc/commit/d7d3a0aed168be92652b6ef2fb69fe9da4eefd95) breaks compilation with master branch of [lxc](https://github.com/lxc/lxc) : the bdev_specs struct has been added to the lxccontainer.h.

I propose to add a new branch that will be dedicated to keep compatibility with the lxc version in ubuntu repository.
