### PR TITLE
Fix build with LXC 3.0

### DIFF
--- a/ext/lxc/lxc.c
+++ b/ext/lxc/lxc.c
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include <stdint.h>
 #include <string.h>
+#include <errno.h>
 
 #define SYMBOL(s) ID2SYM(rb_intern(s))
 


### PR DESCRIPTION
When building `ruby-lxc` with LXC 3.0, I encountered the following error:

```
compiling lxc.c
In file included from
/nix/store/r3hkmi5r6ar270bsqlk9cha3fd4hc62w-lxc-3.0.0/include/lxc/lxccontainer.h:31:0,
                 from lxc.c:4:
lxc.c: In function ‘lxc_attach_parse_options’:
lxc.c:572:41: error: ‘EBADF’ undeclared (first use in this function)
     lxc_attach_options_t default_opts = LXC_ATTACH_OPTIONS_DEFAULT;
```

It can be fixed simply by including `errno.h`.