### PR TITLE
Fix compatibility with liblxc 4.0.4 and newer

### DIFF
--- a/ext/lxc/lxc.c
+++ b/ext/lxc/lxc.c
@@ -42,7 +42,6 @@ extern void *rb_thread_call_without_gvl(void *(*func)(void *), void *data1,
 #endif
 
 extern int lxc_wait_for_pid_status(pid_t pid);
-extern long lxc_config_parse_arch(const char *arch);
 
 static VALUE Container;
 static VALUE Error;
@@ -89,33 +88,6 @@ free_c_string_array(char **arr)
  * a specific container instance) and methods related to +liblxc+. The
  * container-specific methods are contained in the +LXC::Container+ class.
  */
-
-/*
- * call-seq:
- *   LXC.arch_to_personality(arch)
- *
- * Converts an architecture string (x86, i686, x86_64 or amd64) to a
- * "personality", either +:linux32+ or +:linux+, for the 32-bit and 64-bit
- * architectures, respectively.
- */
-static VALUE
-lxc_arch_to_personality(VALUE self, VALUE rb_arch)
-{
-    int ret;
-    char *arch;
-
-    arch = StringValuePtr(rb_arch);
-    ret = lxc_config_parse_arch(arch);
-
-    switch (ret) {
-    case PER_LINUX32:
-        return SYMBOL("linux32");
-    case PER_LINUX:
-        return SYMBOL("linux");
-    default:
-        rb_raise(Error, "unknown personality");
-    }
-}
 
 /*
  * call-seq:
@@ -2127,8 +2099,6 @@ Init_lxc(void)
 {
     VALUE LXC = rb_define_module("LXC");
 
-    rb_define_singleton_method(LXC, "arch_to_personality",
-                               lxc_arch_to_personality, 1);
     rb_define_singleton_method(LXC, "run_command", lxc_run_command, 1);
     rb_define_singleton_method(LXC, "run_shell", lxc_run_shell, 0);
     rb_define_singleton_method(LXC, "global_config_item",

--- a/test/test_lxc_class_methods.rb
+++ b/test/test_lxc_class_methods.rb
@@ -17,9 +17,4 @@ class TestLXCClassMethods < Test::Unit::TestCase
   def test_list_containers
     assert(LXC.list_containers.include?('test'))
   end
-
-  def test_arch_to_personality
-    assert_equal(:linux32, LXC.arch_to_personality('x86'))
-    assert_equal(:linux, LXC.arch_to_personality('x86_64'))
-  end
 end


### PR DESCRIPTION
`ruby-lxc` is broken with LXC 4.0.4 and newer, as two used external functions were removed from liblxc (see #45). This PR makes `ruby-lxc` work again with the following changes:

* `lxc_config_parse_arch()` from liblxc was used in `LXC.arch_to_personality()`. I don't know what can this method be used for, I've just removed it.
* `lxc_wait_for_pid_status()` does nothing special, I've added it's implementation into `ruby-lxc`.

Fixes #45